### PR TITLE
Update move_video.ps1

### DIFF
--- a/src/move_video.ps1
+++ b/src/move_video.ps1
@@ -158,6 +158,10 @@ if ($local:moveToPathTotal -ne 0) {
 		#処理
 		Write-ColorOutput "$($local:moveToPathNum)/$($local:moveToPathTotal) - $($local:moveToPath)" -NoNewline $true
 		$local:targetFolderName = Split-Path -Leaf $local:moveToPath
+		if ($script:sortVideoByMedia) {
+			$local:mediaName = Split-Path -Leaf $(Split-Path -Parent $local:moveToPath)
+			$local:targetFolderName = $(Join-Path $local:mediaName $local:targetFolderName)
+		}
 		#同名フォルダが存在する場合は配下のファイルを移動
 		$local:moveFromPath = $(Join-Path $script:downloadBaseDir $local:targetFolderName)
 		if (Test-Path $local:moveFromPath) {


### PR DESCRIPTION
script:sortVideoByMediaがtrueの場合に、移動元ディレクトリのパスに放送局ディレクトリが含まれておらず動画が移動しなかったため修正。
※放送局名は移動先パスから取得しているため、移動先も放送局で分類している場合のみ使えるコードになっています。放送局名を別のところから取得するorディレクトリを端から走査する等をすればより良くなると思いますが、後者の方は同名番組が他局で放送していたら間違った挙動になる可能性があります。