### PR TITLE
3.2.5 Beta2

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -15,6 +15,7 @@
 ### 3.2.5 Fixed
 
 - フリーワードサーチが失敗する問題を修正
+- Windows GUI版で、個別ダウンロードがエラーとなる問題を修正 [Issue #125](https://github.com/dongaba/TVerRec/issues/125)
 
 ## [3.2.4](https://github.com/dongaba/TVerRec/releases/tag/v3.2.4)
 

--- a/src/download_single.ps1
+++ b/src/download_single.ps1
@@ -42,10 +42,8 @@ while ($true) {
 	#複数アドレス入力用配列
 	$script:videoPageList = @()
 
-	$script:guiMode = $true
-
 	if (!$script:guiMode) {
-		$script:videoPageList = (Read-Host '番組URLを入力してください。何も入力しないで Enter を押すと終了します。スペースで区切って複数入力可能です。').Trim().Split()
+		$script:videoPageList = @((Read-Host '番組URLを入力してください。何も入力しないで Enter を押すと終了します。スペースで区切って複数入力可能です。').Trim().Split())
 	} else {
 		# アセンブリの読み込み
 		Add-Type -AssemblyName System.Windows.Forms | Out-Null

--- a/src/download_single.ps1
+++ b/src/download_single.ps1
@@ -42,6 +42,8 @@ while ($true) {
 	#複数アドレス入力用配列
 	$script:videoPageList = @()
 
+	$script:guiMode = $true
+
 	if (!$script:guiMode) {
 		$script:videoPageList = (Read-Host '番組URLを入力してください。何も入力しないで Enter を押すと終了します。スペースで区切って複数入力可能です。').Trim().Split()
 	} else {
@@ -70,7 +72,7 @@ while ($true) {
 			Size     = New-Object System.Drawing.Size(75, 20)
 			Text     = 'OK'
 		}
-		$okButton.Add_Click({ $script:videoPageList = $inputTextBox.Text.Split("`r`n").Split() ; $inputForm.Close() })
+		$okButton.Add_Click({ $script:videoPageList = @($inputTextBox.Text.Split("`r`n").Split()) ; $inputForm.Close() })
 		$inputForm.Controls.Add($okButton)
 
 		# テキストラベルの作成
@@ -95,7 +97,7 @@ while ($true) {
 	}
 
 	#配列の空白要素を削除
-	$script:videoPageList = $script:videoPageList -ne ''
+	$script:videoPageList = @($script:videoPageList) -ne ''
 	if (-not $script:videoPageList) { break }
 
 	#複数入力されていたら全てダウンロード


### PR DESCRIPTION
## [3.2.5](https://github.com/dongaba/TVerRec/releases/tag/v3.2.5)

### 3.2.5 Added

- Windows用Arm版ffmpegのダウンロード機能を追加

### 3.2.5 Changed

- 「放送分」だけでなく「配信分」からも日付を取得
- サイトマップとトップページにアクセスできない際のエラーを抑止
- TVerIDを登録している状態でもマイページ以外ではTVerIDの情報を使わないように変更

### 3.2.5 Fixed

- フリーワードサーチが失敗する問題を修正
- Windows GUI版で、個別ダウンロードがエラーとなる問題を修正 [Issue #125](https://github.com/dongaba/TVerRec/issues/125)