### PR TITLE
設定ファイル読み込み失敗時の例外メッセージとスタックトレースを出力するように改善

### DIFF
--- a/src/functions/initialize.ps1
+++ b/src/functions/initialize.ps1
@@ -91,12 +91,20 @@ Write-Debug "Message Table Loaded: $script:uiCulture"
 # 設定ファイル読み込み
 if ( Test-Path (Join-Path $script:confDir 'system_setting.ps1') ) {
 	try { . (Convert-Path (Join-Path $script:confDir 'system_setting.ps1')) }
-	catch { throw ($script:msg.LoadSystemSettingFailed) }
+	catch {
+		Write-Error $_
+		Write-Error $_.ScriptStackTrace
+		throw ($script:msg.LoadSystemSettingFailed)
+	}
 } else { throw ($script:msg.SystemSettingNotFound) }
 
 if ( Test-Path (Join-Path $script:confDir 'user_setting.ps1') ) {
 	try { . (Convert-Path (Join-Path $script:confDir 'user_setting.ps1')) }
-	catch { throw ($script:msg.LoadUserSettingFailed) }
+	catch {
+		Write-Error $_
+		Write-Error $_.ScriptStackTrace
+		throw ($script:msg.LoadUserSettingFailed)
+	}
 } elseif ($IsWindows) {
 	Write-Output ($script:msg.UserSettingNeedsToBeCreated)
 	try { & 'gui/gui_setting.ps1' }


### PR DESCRIPTION
### 概要 (Summary)
設定ファイル（ system_setting.ps1 / user_setting.ps1 ）の読み込み（ドットソース読み込み）でエラーが発生した際、具体的な例外内容とエラーが発生した行番号（スタックトレース）をコンソールに出力するように改善しました。

### 背景と目的 (Motivation)
現行の挙動では、設定ファイル内でタイポや未定義変数の参照、文字コードの不整合などによる構文エラーが発生した場合、単に「ユーザ設定ファイルの読み込みに失敗しました」（または「システム設定ファイルの読み込みに失敗しました」）とだけ表示されて強制終了していました。

これでは「設定ファイルの何行目で、何が原因でエラーになっているのか」がユーザー側で分からず、トラブルシューティングが困難になっていました。特にGUI設定画面が使えないMacやLinuxなどのCUI環境において、この問題が初期セットアップのハードルを上げていました。

この変更により、エラー発生時に以下のように具体的な行番号とエラー理由が赤字で出力されるため、ユーザー自身での解決が容易になります。

**出力例（user_setting.ps1の468行目でエラーが起きた場合）:**
```text
Write-Error: /Users/hiroshi/TVerRec/src/loop.ps1:70
The variable '$script:user' cannot be retrieved because it has not been set.
at <ScriptBlock>, /Users/hiroshi/TVerRec/conf/user_setting.ps1: line 468

### 変更内容 (Changes)

•src/functions/initialize.ps1の設定ファイル読み込み処理（try-catchブロック）を変更。
•catchブロック内で発生した例外$_と$.ScriptStackTraceをWrite-Errorを用いて出力するように修正。

### 影響範囲 (Impact)

• 設定ファイルにエラーがない正常起動時は、従来と変わらず追加のログは出力されません。
• 既存の処理や例外のスロー処理自体は変更していないため、他の機能への悪影響はありません。
